### PR TITLE
feat(ngx-store): support to provide injectable middlewares

### DIFF
--- a/apps/example-app/src/app/app.module.ts
+++ b/apps/example-app/src/app/app.module.ts
@@ -4,7 +4,7 @@ import { BrowserModule } from '@angular/platform-browser';
 import { NxModule } from '@nrwl/nx';
 
 import { GridLayoutModule } from '@lacolaco/ngx-grid-layout';
-import { StoreModule } from '@lacolaco/ngx-store';
+import { StoreModule, STORE_MIDDLEWARE } from '@lacolaco/ngx-store';
 import { Middleware } from '@lacolaco/store';
 
 export function loggingMiddleware(next: Middleware) {
@@ -16,17 +16,8 @@ export function loggingMiddleware(next: Middleware) {
 }
 
 @NgModule({
-  imports: [
-    BrowserModule,
-    NxModule.forRoot(),
-    GridLayoutModule,
-    StoreModule.forRoot(
-      {},
-      {
-        middlewares: [loggingMiddleware],
-      },
-    ),
-  ],
+  imports: [BrowserModule, NxModule.forRoot(), GridLayoutModule, StoreModule.forRoot({})],
+  providers: [{ provide: STORE_MIDDLEWARE, useValue: loggingMiddleware, multi: true }],
   declarations: [AppComponent],
   bootstrap: [AppComponent],
 })

--- a/libs/ngx-store/index.ts
+++ b/libs/ngx-store/index.ts
@@ -1,1 +1,1 @@
-export { StoreModule } from './src/store.module';
+export { StoreModule, STORE_MIDDLEWARE } from './src/store.module';


### PR DESCRIPTION
BREAKING CHANGE:

`STORE_CONFIG` token is removed.
Use `STORE_MIDDLEWARE` to set middlewares instead.